### PR TITLE
Issue 24 account name conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *swp
+.idea

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ ACCOUNT=<your desired account>
 ROLE=<your desired role>
 HOST=<your afp host>
 _PATH=<your path to service endpoint, typically "/afp-api/latest/account">
+PATTERN="${ACCOUNT}|${ROLE}" # optional, the message you want to see in front of the prompt
 NAME=<your username> # optional
 PW=<your password> # optional, I wouldn't put it here
 RENEW_INT=<custom token renew interval> # optional, defaults to token's expiry

--- a/afpre
+++ b/afpre
@@ -61,6 +61,7 @@ ACCOUNT=my.account
 ROLE=my.role
 HOST=my.afp.host
 _PATH=/afp-api/latest/account
+#PATTERN="\${ACCOUNT}|\${ROLE}" # This will appear in front of the prompt
 #NAME=my.name
 #PW=my.password # I wouldn't put it here
 EOF
@@ -159,7 +160,7 @@ PROMPT_COMMAND="{
         }
 }"
 
-PS1="AFP|${ACCOUNT}|${ROLE} \$PS1"
+PS1="AFP|${PATTERN} \$PS1"
 EOF
 
 RCFILE=$(mktemp)

--- a/afpre
+++ b/afpre
@@ -42,9 +42,10 @@ do_help() {
 usage: ${0} [OPTIONS]
 
 OPTIONS
-  --help        ... print this help
-  --example-cfg ... create an example config file at ${CFG}
-  --debug       ... enable debugging
+  --help                    ... print this help
+  --account ACCOUNT_NAME    ... authenticate towards this account name
+  --example-cfg             ... create an example config file at ${CFG}
+  --debug                   ... enable debugging
 EOF
 	echo "${HELP}"
 	exit 0
@@ -71,6 +72,7 @@ EOF
 DEBUG=false
 
 options_contain '--help' "$@" && do_help
+options_contain '--account' "$@" && ACCOUNT_NAME="${2}"
 options_contain '--example-cfg' "$@" && do_example_cfg
 options_contain '--debug' "$@" && DEBUG=true
 
@@ -80,12 +82,18 @@ check_dep curl
 check_dep jq
 check_dep openssl
 check_config_file
-check_config_key ACCOUNT
+if [ -z ${ACCOUNT_NAME+x} ]; then
+    check_config_key ACCOUNT
+fi
 check_config_key ROLE
 check_config_key _PATH
 check_config_key HOST
 
 source $CFG
+
+if [ ! -z ${ACCOUNT_NAME+x} ]; then
+    ACCOUNT="${ACCOUNT_NAME}"
+fi
 
 variable_empty "${NAME}" && {
 	echo -n "username: " && read NAME

--- a/afpre
+++ b/afpre
@@ -151,7 +151,7 @@ PROMPT_COMMAND="{
         }
 }"
 
-PS1="AFP| \$PS1"
+PS1="AFP|${ACCOUNT}|${ROLE} \$PS1"
 EOF
 
 RCFILE=$(mktemp)


### PR DESCRIPTION
The account name is made configurable through --account option.
The Pattern in front of the prompt is made configurable through PATTERN variable in the cfg.
Readme and --example-cfg generation updated accordingly.